### PR TITLE
SimpleHttpHandler: fix PHP's $_COOKIE serialization

### DIFF
--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/SimpleHttpHandler.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/SimpleHttpHandler.php
@@ -132,21 +132,71 @@ class SimpleHttpHandler extends SocketHandler
     }
 
     /**
+     * Serialize PHP's $_COOKIE values into a valid HTTP COOKIE string
      *
      * @return string
      */
     public function getCookies()
     {
-        $str = "";
-        $first = true;
-        foreach ($_COOKIE as $k => $v) {
-            $str .=($first ? "Cookie: $k=$v" : "; $k=$v");
-            $first = false;
+        $cookieParts = [];
+        foreach($_COOKIE as $k => $v) {
+            $cookieParts[] = $this->serializePHPCookies($k, $v);
         }
-        if (!$first) {
-            $str .="\r\n";
+
+        if (!count($cookieParts)) {
+            return '';
         }
-        return $str;
+
+        $fullCookieString = 'Cookie: ' . implode(';', $cookieParts) . "\r\n";
+
+        return  $fullCookieString;
+    }
+
+    /**
+     * Escapes $cookieValue taking into account its type to serialize it as a valid cookie value
+     *
+     * @param string $cookieName
+     * @param mixed $cookieValue
+     *
+     * @return string
+     */
+    private function serializePHPCookies($cookieName, $cookieValue)
+    {
+
+        $urlEncodedCookieName = urlencode($cookieName);
+        $valueType = gettype($cookieValue);
+        switch($valueType) {
+
+            case 'integer':
+            case 'double':
+            case 'string':
+                $urlEncodedCookieValue = urlencode($cookieValue);
+                $cookieParts[] = "$urlEncodedCookieName=$urlEncodedCookieValue";
+                break;
+
+            case 'array':
+                foreach($cookieValue as $cookieValueKey => $cookieValueValue) {
+                    $cookieParts[] = $this->serializePHPCookies($cookieName . "[$cookieValueKey]", $cookieValueValue);
+                }
+                break;
+
+            case 'NULL':
+                $cookieParts[] = "$urlEncodedCookieName=";
+                break;
+
+            case 'boolean':
+                $cookieParts[] = "$urlEncodedCookieName=" . $cookieValue ? '1' : '0';
+                break;
+
+            // It's a security risk to serialize an object and send it as a cookie
+            case 'object':
+                // Intentional fallthrough
+            default:
+                $cookieParts[] = "$urlEncodedCookieName=_UNSUPPORTED_TYPE_";
+                break;
+        }
+
+        return implode(';', $cookieParts);
     }
 
     /**


### PR DESCRIPTION
Hi, 

First for all thank you for the excellent work you have done by making the PHP/Java bridge up to date and compatible with PHP7 - we were happy at the office to find it in our transition to PHP7.

This pull request fixes an issue when there are values in PHP's `$_COOKIE` super global that are not simple scalars (like arrays). We stumbled upon the problem when there was a cookie in the form `name[0]=somevalue` set from the client that caused an "array to string conversion" exception on the bridge. 

The prolematic piece of code is the following:

``` php
    /**
     *
     * @return string
     */
    public function getCookies()
    {
        $str = "";
        $first = true;
        foreach ($_COOKIE as $k => $v) {
            $str .=($first ? "Cookie: $k=$v" : "; $k=$v");
            $first = false;
        }
        if (!$first) {
            $str .="\r\n";
        }
        return $str;
    }

```

If `$v` is an array or other non-scalar value there will be an implicit conversion to string.

In this PR you'll see that objects are unsupported - I don't know if this is the right approach, but definitively I wouldn't recommend to serialize them due to the security implications.
