### PR TITLE
XML parser option to forcibly use SimpleParser instead of NativeParser

### DIFF
--- a/src/Soluble/Japha/Bridge/Adapter.php
+++ b/src/Soluble/Japha/Bridge/Adapter.php
@@ -48,7 +48,8 @@ class Adapter
      *     'driver' => 'Pjb62',
      *     'servlet_address' => 'http://127.0.0.1:8080/javabridge-bundle/java/servlet.phpjavabridge'
      *      //'java_default_timezone' => null,
-     *      //'java_prefer_values' => true
+     *      //'java_prefer_values' => true,
+     *      //'force_simple_xml_parser' => false
      *    ]);
      *
      * </code>

--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/Client.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/Client.php
@@ -222,7 +222,7 @@ class Client
 
         $this->RUNTIME = [];
         $this->RUNTIME['NOTICE'] = '***USE echo $adapter->getDriver()->inspect(jVal) OR print_r($adapter->values(jVal)) TO SEE THE CONTENTS OF THIS JAVA OBJECT!***';
-        $this->parser = new Parser($this);
+        $this->parser = new Parser($this, $params['XML_PARSER_FORCE_SIMPLE_PARSER'] ?? false);
         $this->protocol = new Protocol($this, $this->java_hosts, $this->java_servlet, $this->java_recv_size, $this->java_send_size);
         $this->simpleFactory = new SimpleFactory($this);
         $this->proxyFactory = new ProxyFactory($this);

--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/Parser.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/Parser.php
@@ -52,7 +52,7 @@ class Parser
      * @param Client $handler
      * @param bool $forceSimpleParser - Always use SimpleParser, even if NativeParser can be used
      */
-    public function __construct(Client $handler, bool $forceSimpleParser)
+    public function __construct(Client $handler, bool $forceSimpleParser = false)
     {
         if ($forceSimpleParser || defined('HHVM_VERSION') || !function_exists('xml_parser_create')) {
             // Later on maybe a version_compare(HHVM_VERSION, '3.8.0', '<')

--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/Parser.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/Parser.php
@@ -44,19 +44,24 @@ class Parser
      */
     protected $parser;
 
+    const PARSER_NATIVE = 'NATIVE';
+
+    const PARSER_SIMPLE = 'SIMPLE';
+
     /**
      * @param Client $handler
+     * @param bool $forceSimpleParser - Always use SimpleParser, even if NativeParser can be used
      */
-    public function __construct(Client $handler)
+    public function __construct(Client $handler, bool $forceSimpleParser)
     {
-        if (defined('HHVM_VERSION') || !function_exists('xml_parser_create')) {
+        if ($forceSimpleParser || defined('HHVM_VERSION') || !function_exists('xml_parser_create')) {
             // Later on maybe a version_compare(HHVM_VERSION, '3.8.0', '<')
             // xml_parser bugs in hhvm at least version 3.7.0
             $this->parser = new SimpleParser($handler);
-            $handler->RUNTIME['PARSER'] = 'SIMPLE';
+            $handler->RUNTIME['PARSER'] = self::PARSER_SIMPLE;
         } else {
             $this->parser = new NativeParser($handler);
-            $handler->RUNTIME['PARSER'] = 'NATIVE';
+            $handler->RUNTIME['PARSER'] = self::PARSER_NATIVE;
         }
     }
 

--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/Pjb62Driver.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/Pjb62Driver.php
@@ -41,8 +41,9 @@ class Pjb62Driver extends AbstractDriver
      *      //'java_prefer_values' => true,
      *      //'java_log_level' => null,
      *      //'java_send_size' => 8192,
-     *      //'java_recv_size' => 8192
-     *      //'internal_encoding' => 'UTF-8'
+     *      //'java_recv_size' => 8192,
+     *      //'internal_encoding' => 'UTF-8',
+     *      //'force_simple_xml_parser' => false
      *    ], $logger);
      *
      * </code>

--- a/src/Soluble/Japha/Bridge/Driver/Pjb62/PjbProxyClient.php
+++ b/src/Soluble/Japha/Bridge/Driver/Pjb62/PjbProxyClient.php
@@ -43,6 +43,9 @@ class PjbProxyClient implements ClientInterface
         // so the value is always transferred for those types. If you put
         // at false you'll have to rework on the code.
         'java_prefer_values' => true,
+        // use SimpleParser (pure PHP code) even if NativeParser (based on xml_* php functions) may be used
+        // should only be used to workaround bugs or limitations regarding the xml extension
+        'force_simple_xml_parser' => false
     ];
 
     /**
@@ -99,7 +102,7 @@ class PjbProxyClient implements ClientInterface
      */
     protected function __construct(array $options, LoggerInterface $logger)
     {
-        $this->options = new ArrayObject(array_merge($options, $this->defaultOptions));
+        $this->options = new ArrayObject(array_merge($this->defaultOptions, $options));
         self::$instanceOptionsKey = serialize((array) $this->options);
 
         $this->logger = $logger;
@@ -202,7 +205,8 @@ class PjbProxyClient implements ClientInterface
             $params['JAVA_SEND_SIZE'] = $options['java_send_size'];
             $params['JAVA_RECV_SIZE'] = $options['java_recv_size'];
             $params['JAVA_LOG_LEVEL'] = $options['java_log_level'];
-
+            $params['XML_PARSER_FORCE_SIMPLE_PARSER'] = $options['force_simple_xml_parser'];
+            
             self::$client = new Client($params, $this->logger);
 
             // Added in order to work with custom exceptions


### PR DESCRIPTION
Hi Sébastien,

At work we have been through a couple of busy days to diagnose and workaround a problem in PHP's `xml_parse` native functions while parsing large values in XML attributes. 

The problem is that `xml_parse` (at least from PHP 5.5 to PHP 7.1) limits the maximum size of any XML node's attribute value to 10M (it can progressively parse XML files of any size, but not attribute values of any size - find [here](https://github.com/belgattitude/soluble-japha/files/1141216/xml_parser_limits.zip) a script that I created to demostrate that).  This seems related to the change that was done to `libxml2` to limit the memory while parsing. The option `XML_PARSE_HUGE` can be passed to the C library to overcome that limitation, but sadly PHP's `xml_parse` does not supports it yet.

As we use soluble-japha mainly for Jasper Reports, when there is a PDF of a couple thousand pages, the response will come as a base64-encoded XML node attribute value that is easily greater than the `xml_parser` limit of 10M.

This PR adds the following features:

* Hint the Parser class to always use `SimpleParser` instead of `NativeParser`. The SimpleParser parses huge Pjb62 without any problem.

And fixes the following issues:

* Default options on `PjbProxyClient` were impossible to be overriden.

Due to the nested singleton objects I had some trouble to create the unit tests. I finally settled on using reflection to force the re initialization of the `PjbProxyClient` object and be able to unit test its configuration.

Right now my hacky workaround is to artificially define the `HHVM_VERSION` constant to fool the `Parser` class into using `SimpleParser` (yeah, I know...).